### PR TITLE
Fix misalignment, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Get to the Command Palette and then you can run:
 
 `Stretchy Spaces: Enable` - to enable the extension within the current running vscode instance.
 
+## Guides
+
+If you have indent guides enabled, they will still appear at the unadjusted locations. Either disable them:
+
+```js
+"editor.renderIndentGuides": false
+```
+
+Or install the [Guides](https://marketplace.visualstudio.com/itemdetails?itemName=spywhere.guides) extension to replace them with ones that are compatible with this extension.
 
 ## Other Info
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ Although you can just use it as it is there is the possibility to configure some
   // How many spaces do you wish the indentation was? The extension will *try* to match this.
   "stretchySpaces.targetIndentation": 4
 
-  // For which languages indent-rainbow should be activated (if empty it means all).
+  // For which languages Stretchy Spaces should be activated (if empty it means all).
   "stretchySpaces.includedLanguages": [] // for example ["nim", "nims", "python"]
 
-  // For which languages indent-rainbow should be deactivated (if empty it means none).
+  // For which languages Stretchy Spaces should be deactivated (if empty it means none).
   "stretchySpaces.excludedLanguages": [] // for example ["plaintext"]
 
   // The delay in ms until the editor gets updated.
   "stretchySpaces.updateDelay": 100 // 10 makes it super fast but may cost more resources
 ```
 
-*Notice: Defining both `includedLanguages` and `excludedLanguages` does not make much sense. Use one of both!*
+*Notice: Adding the same language to both `includedLanguages` and `excludedLanguages` does not make much sense. Use one or the other, not both!*
 
 ## Commands
 

--- a/extension.js
+++ b/extension.js
@@ -103,7 +103,12 @@ function activate(context) {
             return;
         }
         const decorationRanges = [];
-        const regEx = /^ +(?!\*)/gm; // Spaces from the start of the line until before the space before a *, to preserve JSDoc-style comments alignment
+        let regEx;
+        if (vscode.workspace.getConfiguration('stretchySpaces').alignAsterisks) {
+            regEx = /^ +(?!\*)/gm; // Spaces from the start of the line until before the space before a *, to preserve JSDoc-style comments alignment
+        } else {
+            regEx = /^ +/gm;
+        }
         const text = activeEditor.document.getText();
 
         if (!currentIndentDecorationType) {

--- a/extension.js
+++ b/extension.js
@@ -98,8 +98,7 @@ function activate(context) {
             return;
         }
         const targetIndentation = vscode.workspace.getConfiguration('stretchySpaces').targetIndentation;
-        const indentFactor = targetIndentation / activeEditor.options.tabSize;
-        if (!activeEditor.options.insertSpaces || indentFactor === 1) {
+        if (!activeEditor.options.insertSpaces || targetIndentation === activeEditor.options.tabSize) {
             return;
         }
         const decorationRanges = [];

--- a/extension.js
+++ b/extension.js
@@ -107,8 +107,12 @@ function activate(context) {
         const text = activeEditor.document.getText();
 
         if (!currentIndentDecorationType) {
+            // 4 spaces rendered as 2, or 50% less: -0.5ch
+            // 2 spaces rendered as 4, or 100% more: 1ch
+            // current + percentChange × current = target
+            const percentChange = (targetIndentation - activeEditor.options.tabSize) / activeEditor.options.tabSize;
             currentIndentDecorationType = vscode.window.createTextEditorDecorationType({
-                letterSpacing: 8 * indentFactor - 8 + 'px'
+                letterSpacing: percentChange + 'ch' // https://css-tricks.com/the-lengths-of-css/#ch
             });
         }
 

--- a/extension.js
+++ b/extension.js
@@ -103,7 +103,7 @@ function activate(context) {
             return;
         }
         const decorationRanges = [];
-        const regEx = /^ +/gm;
+        const regEx = /^ +(?!\*)/gm; // Spaces from the start of the line until before the space before a *, to preserve JSDoc-style comments alignment
         const text = activeEditor.document.getText();
 
         if (!currentIndentDecorationType) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "stretchy-spaces",
     "displayName": "stretchy-spaces",
     "description": "Allows you to change how wide your indentation spaces are.",
-    "version": "0.0.3",
+    "version": "0.1.0",
     "publisher": "kylepaulsen",
     "author": {
         "name": "Kyle Paulsen"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
                     "default": [],
                     "description": "For which languages Stretchy Spaces should be deactivated. When left empty will ignore."
                 },
+                "stretchySpaces.alignAsterisks": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Leave at normal width a space before an asterisk in an indentation, to preserve the alignment of the asterisks in /* ... */ comments where each line begins with an asterisk."
+                },
                 "stretchySpaces.updateDelay": {
                     "type": "integer",
                     "default": 100,

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
                 "stretchySpaces.includedLanguages": {
                     "type": "array",
                     "default": [],
-                    "description": "For which languages indent-rainbow should be activated. When empty will use for all languages."
+                    "description": "For which languages Stretchy Spaces should be activated. When empty will use for all languages."
                 },
                 "stretchySpaces.excludedLanguages": {
                     "type": "array",
                     "default": [],
-                    "description": "For which languages indent-rainbow should be deactivated. When left empty will ignore."
+                    "description": "For which languages Stretchy Spaces should be deactivated. When left empty will ignore."
                 },
                 "stretchySpaces.updateDelay": {
                     "type": "integer",


### PR DESCRIPTION
Thank you for creating this extension. On my machine the alignment of the indentations was a little off, perhaps because I’m using a different font. Here’s what I see for 4 spaces rendered as the width of 2 spaces:

![image](https://user-images.githubusercontent.com/456802/91257855-c860a200-e71f-11ea-98d3-50df9e9e664c.png)

It’s more obvious when looking at letters:

![image](https://user-images.githubusercontent.com/456802/91258056-48870780-e720-11ea-87e7-76c2198b41db.png)

Looking at the code of the extension, I see that it assumes that spaces are always 8px wide. This must not be the case for me. We can instead use the [`ch` CSS unit](https://css-tricks.com/the-lengths-of-css/#ch) to create a CSS rule that’s relative to the width of the character of the font in use. `letter-spacing: -0.5ch` makes 4 spaces appear as 2, and `letter-spacing: 1ch` makes 2 spaces appear as 4 (50% less or 100% more, respectively). This PR makes that change, which fixes the misalignments for me:

_4 as 2:_
![image](https://user-images.githubusercontent.com/456802/91258523-66a13780-e721-11ea-866b-b8ef969103af.png)

_2 as 4:_
![image](https://user-images.githubusercontent.com/456802/91258591-918b8b80-e721-11ea-9c90-6a735a57997e.png)


I also updated the README per https://github.com/kylepaulsen/vscode-stretchy-spaces/issues/3#issuecomment-482291773 to tell people how to fix their guides, to solve #3.