### PR TITLE
Fix included/excluded languages, temp extra spacing when when typing, and inline diff editor

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -120,7 +120,8 @@ function activate(context) {
             // current + percentChange × current = target
             const percentChange = (targetIndentation - activeEditor.options.tabSize) / activeEditor.options.tabSize;
             currentIndentDecorationType = vscode.window.createTextEditorDecorationType({
-                letterSpacing: percentChange + 'ch' // https://css-tricks.com/the-lengths-of-css/#ch
+                letterSpacing: percentChange + 'ch', // https://css-tricks.com/the-lengths-of-css/#ch
+                rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed
             });
         }
 

--- a/extension.js
+++ b/extension.js
@@ -7,6 +7,7 @@ function activate(context) {
     let timeout = null;
     let enabled = true;
     let currentLanguageId = null;
+    let currentLanguageEnabled = false;
     let activeEditor = vscode.window.activeTextEditor;
 
     let currentIndentDecorationType;
@@ -57,22 +58,23 @@ function activate(context) {
     function checkLanguage() {
         if (activeEditor) {
             if (currentLanguageId !== activeEditor.document.languageId) {
+                currentLanguageEnabled = true
                 const inclang = vscode.workspace.getConfiguration('stretchySpaces').includedLanguages || [];
                 const exclang = vscode.workspace.getConfiguration('stretchySpaces').excludedLanguages || [];
                 currentLanguageId = activeEditor.document.languageId;
                 if (inclang.length !== 0) {
                     if (inclang.indexOf(currentLanguageId) === -1) {
-                        return false;
+                        currentLanguageEnabled = false;
                     }
                 }
                 if (exclang.length !== 0) {
                     if (exclang.indexOf(currentLanguageId) !== -1) {
-                        return false;
+                        currentLanguageEnabled = false;
                     }
                 }
             }
         }
-        return true;
+        return currentLanguageEnabled;
     }
 
     function clearDecorations() {


### PR DESCRIPTION
First I would like to say thank you so much for this extension.  This is one of my most favorite extensions in any IDE ever!

I have 3 bug fixes in this PR, each completed in their own commit.  I'm submitting them together in a single PR for simplicity, but if you would prefer them to be separated out I would be happy to do that.

I've been testing these fixes for the past month with no issues.

## 1. Fix for included/excluded languages

#### Issue
1. Configure the following settings
```
    "stretchySpaces.includedLanguages": [
        "java"
    ],
    "editor.tabSize": 2
```
2. Open a plaintext file with some lines indented with 2 spaces.  When first opened, stretchy-spaces is not enabled on the editor as expected (per the configuration)
3. However, once you start modifying the file, stretchy-spaces is incorrectly enabled

#### Fix
The root cause is the `checkLanguage` function checks to see if the languageId has changed, and if it has not then it always returns true.  My fix is when the languageId has not changed, to return the same value as the previous check.

## 2. Fix spaces briefly appear between characters on a new line. (#4)

Fixed by setting the range behavior on each range to [ClosedClosed](https://code.visualstudio.com/api/references/vscode-api#DecorationRangeBehavior).

## 3. Fix inline diff editors don't work correctly

Inline diff editor uses stretchy-spaces for unchanged and added lines, however deleted lines do not have spaces stretched.

Example: In this screenshot the indentation has not been changed, however stretchy-spaces makes it appear it has changed:
![image](https://github.com/kylepaulsen/vscode-stretchy-spaces/assets/5075659/52f45723-1167-4a4d-95d3-94058f1e1ce9)

Since the extension can't stretch the indentation on the deleted lines in inline mode, I disabled decorations when the editor is a diff editor and in inline mode.  I also added an onDidChangeConfiguration listener for when the diff editor is toggled between inline and side-by-side mode.

To determine if the editor is a diff editor, I used some information from https://github.com/microsoft/vscode/issues/15513#issuecomment-1245403215

Sometimes when switching from side-by-side to inline, clear decorations doesn't work.  I'm not sure why - I tried multiple things, including executing clearDecorations using setTimeout, and not creating a new currentIndentDecorationType object.  To work around this scenario, I open a new file and immediately close it.  The editor is refreshed and it works well.  This is admittedly a hack-y work around, but I have not noticed any issues.

